### PR TITLE
ARM64 native Docker image and pipeline fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ The pipeline assumes your data is organized according to the
 Build the image:
 
 ```bash
+# For x86_64 / GPU systems:
 docker build -f docker/dockerfile -t anat2vessels:latest .
+
+# For Apple Silicon (M-series, ARM64, CPU-only):
+docker build -f docker/dockerfile.arm64 -t anat2vessels:arm64 .
 ```
 
 Run the full pipeline (preprocess + inference + feature extraction) in one command:
 
 ```bash
-docker run --gpus=1 \
+docker run $([ "$(uname -m)" = "arm64" ] || echo "--gpus=1") \
   -v /path/to/bids:/data/bids \
   -v /path/to/results:/data/results \
   anat2vessels:latest all \
@@ -34,19 +38,22 @@ Or run individual steps:
 
 ```bash
 # Step 1: Preprocess
-docker run --gpus=1 -v /path/to/bids:/data/bids -v /path/to/results:/data/results \
+docker run $([ "$(uname -m)" = "arm64" ] || echo "--gpus=1") \
+  -v /path/to/bids:/data/bids -v /path/to/results:/data/results \
   anat2vessels:latest preprocess \
   --bids_dir /data/bids --output_dir /data/results/preprocessed \
   --model t1t2 --skull_strip
 
 # Step 2: nnUNet inference
-docker run --gpus=1 -v /path/to/results:/data/results \
+docker run $([ "$(uname -m)" = "arm64" ] || echo "--gpus=1") \
+  -v /path/to/results:/data/results \
   anat2vessels:latest predict \
   --input_dir /data/results/preprocessed --output_dir /data/results/predictions \
   --model t1t2
 
 # Step 3: Feature extraction
-docker run --gpus=1 -v /path/to/results:/data/results \
+docker run $([ "$(uname -m)" = "arm64" ] || echo "--gpus=1") \
+  -v /path/to/results:/data/results \
   anat2vessels:latest features \
   --input_dir /data/results/predictions --output_path /data/results/features.csv
 ```
@@ -58,6 +65,56 @@ docker run --gpus=1 -v /path/to/results:/data/results \
 | `t1t2` | Combined T1 + T2 (default) |
 
 Note: GPU support requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+On Apple Silicon, the ARM64 image runs natively without GPU emulation.
+Omit `--gpus` and nnUNet will automatically use the CPU.
+
+### Running on the test dataset
+
+The package includes a small test dataset downloaded from Hugging Face on
+first use. To run the full pipeline on it:
+
+```bash
+# Build (choose the image for your platform)
+docker build -f docker/dockerfile -t anat2vessels:latest .
+# or: docker build -f docker/dockerfile.arm64 -t anat2vessels:arm64 .
+
+To avoid re-downloading model weights and test data on every run,
+mount the local pooch cache into the container:
+
+```bash
+mkdir -p ~/.cache/anat2vessels
+```
+
+Add `-v ~/.cache/anat2vessels:/root/.cache/anat2vessels` to any
+`docker run` command in this section to reuse previously downloaded
+files instead of fetching them from Hugging Face each time.
+
+For example:
+
+```bash
+mkdir -p ~/.cache/anat2vessels
+docker run --rm \
+  -v ~/.cache/anat2vessels:/root/.cache/anat2vessels \
+  -v /tmp/bids:/data \
+  anat2vessels:latest fetch-test-data --output-dir /data
+```
+
+# Run the full pipeline (GPU)
+docker run --gpus=1 \
+  -v /tmp/bids:/data/bids:ro \
+  -v /tmp/results:/data/results \
+  anat2vessels:latest all \
+  --bids_dir /data/bids --output_dir /data/results \
+  --model t1t2 --skull_strip
+
+# Or run on ARM64 (Apple Silicon)
+docker run \
+  -v /tmp/bids:/data/bids:ro \
+  -v /tmp/results:/data/results \
+  anat2vessels:arm64 all \
+  --bids_dir /data/bids --output_dir /data/results \
+  --model t1t2
+```
 
 ### Local installation
 

--- a/docker/dockerfile.arm64
+++ b/docker/dockerfile.arm64
@@ -1,0 +1,25 @@
+FROM --platform=linux/arm64 python:3.11-slim
+
+RUN pip install --no-cache-dir torch==2.5.1 \
+        --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir nnunetv2 \
+    && pip install --no-cache-dir antspyx==0.4.2 antspynet
+
+RUN mkdir -p /data/nnUNet_raw \
+    && mkdir -p /data/nnUNet_preprocessed \
+    && mkdir -p /data/nnUNet_results
+
+ENV nnUNet_raw="/data/nnUNet_raw"\
+    nnUNet_preprocessed="/data/nnUNet_preprocessed"\
+    nnUNet_results="/data/nnUNet_results"
+
+COPY pyproject.toml README.md /src/anat2vessels/
+COPY src/ /src/anat2vessels/src/
+RUN pip install --no-cache-dir -e "/src/anat2vessels"
+
+COPY docker/entrypoint.py /usr/local/bin/a2v-pipeline
+RUN chmod +x /usr/local/bin/a2v-pipeline
+
+WORKDIR /data
+
+ENTRYPOINT ["a2v-pipeline"]

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -18,9 +18,9 @@ NNUNET_PARAMS = {
     },
     "t1t2": {
         "dataset": "096",
-        "trainer": "nnUNetTrainerCLDLoss",
+        "trainer": "nnUNetTrainer",
         "config": "3d_fullres",
-        "plans": "nnUNetResEncUNetMPlans",
+        "plans": "nnUNetResEncUNetLPlans",
     },
 }
 
@@ -54,7 +54,7 @@ def cmd_predict(args):
         args.output_dir,
         "-f",
     ]
-    if args.folds:
+    if getattr(args, "folds", None):
         cmd += args.folds.split()
     else:
         cmd += ["0", "1", "2", "3", "4"]
@@ -68,8 +68,19 @@ def cmd_predict(args):
         params["plans"],
     ]
     if args.device:
-        cmd += ["--device", args.device]
+        cmd += ["-device", args.device]
     subprocess.run(cmd, env=env, check=True)
+
+
+def cmd_fetch_test_data(args):
+    import shutil
+    from anat2vessels.data.fetch import fetch_bids_dataset
+
+    src = fetch_bids_dataset()
+    dst = args.output_dir
+    os.makedirs(dst, exist_ok=True)
+    shutil.copytree(src, dst, dirs_exist_ok=True)
+    print(f"Test data written to {dst}")
 
 
 def cmd_features(args):
@@ -101,6 +112,7 @@ def cmd_all(args):
         output_dir=pred_dir,
         model=args.model,
         device=args.device,
+        folds=args.folds,
     )
     cmd_predict(predict_args)
 
@@ -140,6 +152,12 @@ def main():
     p_feat.add_argument("--no_ray", action="store_true")
     p_feat.set_defaults(func=cmd_features)
 
+    p_fetch = subparsers.add_parser(
+        "fetch-test-data", help="Download test BIDS dataset"
+    )
+    p_fetch.add_argument("--output-dir", required=True, dest="output_dir")
+    p_fetch.set_defaults(func=cmd_fetch_test_data)
+
     p_all = subparsers.add_parser("all", help="Run full pipeline")
     p_all.add_argument("--bids_dir", required=True)
     p_all.add_argument("--output_dir", required=True)
@@ -147,6 +165,7 @@ def main():
     p_all.add_argument("--skull_strip", action="store_true")
     p_all.add_argument("--no_ray", action="store_true")
     p_all.add_argument("--device", default=None)
+    p_all.add_argument("--folds", default=None)
     p_all.set_defaults(func=cmd_all)
 
     parsed = parser.parse_args()

--- a/src/anat2vessels/preprocess.py
+++ b/src/anat2vessels/preprocess.py
@@ -104,15 +104,16 @@ def preprocess_bids(
         futures = []
         for sub in subjects:
             futures.append(
-                remote_func.remote(layout, sub, model, skull_strip, output_dir)
+                remote_func.remote(bids_dir, sub, model, skull_strip, output_dir)
             )
         ray.get(futures)
     else:
         for sub in subjects:
-            _preprocess_subject(layout, sub, model, skull_strip, output_dir)
+            _preprocess_subject(bids_dir, sub, model, skull_strip, output_dir)
 
 
-def _preprocess_subject(layout, subject, model, skull_strip, output_dir):
+def _preprocess_subject(bids_dir, subject, model, skull_strip, output_dir):
+    layout = BIDSLayout(bids_dir)
     if model in ("t1", "t1t2"):
         _process_modality(
             layout,

--- a/src/anat2vessels/vessels2csv.py
+++ b/src/anat2vessels/vessels2csv.py
@@ -36,7 +36,7 @@ def main(args):
 
 
 def ray_main(args):
-    ray.init(num_cpus=(cpu_count() - 1))
+    ray.init(num_cpus=(cpu_count() - 1), ignore_reinit_error=True)
     data_list = []
 
     remote = ray.remote(extract_features)

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -370,55 +370,44 @@ class TestBidsPreprocessing:
         assert not os.path.exists(os.path.join(out_dir, "01_0000.nii.gz"))
 
     def test_preprocess_subject_t1(self, tmp_path):
-        layout = avp.BIDSLayout(self._bids_dir, validate=False)
         out_dir = str(tmp_path / "t1_only")
         os.makedirs(out_dir)
         original_ref = avp._get_ref_path
         avp._get_ref_path = lambda: self._ref_path
         try:
             avp._preprocess_subject(
-                layout, "01", "t1", skull_strip=False, output_dir=out_dir
+                self._bids_dir, "01", "t1", skull_strip=False, output_dir=out_dir
             )
         finally:
             avp._get_ref_path = original_ref
         assert os.path.exists(os.path.join(out_dir, "01_0000.nii.gz"))
 
     def test_preprocess_subject_t2(self, tmp_path):
-        layout = avp.BIDSLayout(self._bids_dir, validate=False)
-        subjects = layout.get_subjects()
-        if not any(
-            layout.get(subject=s, suffix="T2w", return_type="file") for s in subjects
-        ):
-            pytest.skip("No subject with T2w in BIDS dataset")
         out_dir = str(tmp_path / "t2_only")
         os.makedirs(out_dir)
         original_ref = avp._get_ref_path
         avp._get_ref_path = lambda: self._ref_path
         try:
             avp._preprocess_subject(
-                layout, subjects[0], "t2", skull_strip=False, output_dir=out_dir
+                self._bids_dir, "01", "t2", skull_strip=False, output_dir=out_dir
             )
         finally:
             avp._get_ref_path = original_ref
-        assert os.path.exists(os.path.join(out_dir, f"{subjects[0]}_0000.nii.gz"))
+        assert os.path.exists(os.path.join(out_dir, "01_0000.nii.gz"))
 
     def test_preprocess_subject_t1t2(self, tmp_path):
-        layout = avp.BIDSLayout(self._bids_dir, validate=False)
-        subjects = layout.get_subjects()
-        if not subjects:
-            pytest.skip("No subjects in BIDS dataset")
         out_dir = str(tmp_path / "t1t2_full")
         os.makedirs(out_dir)
         original_ref = avp._get_ref_path
         avp._get_ref_path = lambda: self._ref_path
         try:
             avp._preprocess_subject(
-                layout, subjects[0], "t1t2", skull_strip=False, output_dir=out_dir
+                self._bids_dir, "01", "t1t2", skull_strip=False, output_dir=out_dir
             )
         finally:
             avp._get_ref_path = original_ref
-        assert os.path.exists(os.path.join(out_dir, f"{subjects[0]}_0000.nii.gz"))
-        assert os.path.exists(os.path.join(out_dir, f"{subjects[0]}_0001.nii.gz"))
+        assert os.path.exists(os.path.join(out_dir, "01_0000.nii.gz"))
+        assert os.path.exists(os.path.join(out_dir, "01_0001.nii.gz"))
 
     def test_preprocess_bids_empty_dir(self, tmp_path):
         empty = str(tmp_path / "empty")


### PR DESCRIPTION
Add docker/dockerfile.arm64 for Apple Silicon (M-series):
  - Based on python:3.11-slim with PyTorch CPU (no CUDA)
  - Pin antspyx==0.4.2 for pre-built ARM64 wheels (avoids source compilation failure)
  - Build nnUNet, antspyx, antspynet all via pip

Fix docker/entrypoint.py:
  - Correct t1t2 model params: nnUNetTrainer not CLDLoss, LPlans not MPlans
  - Use -device (single dash) for nnUNetv2_predict; accept 'cpu' value
  - Add fetch-test-data subcommand for downloading BIDS test dataset
  - Plumb --folds through cmd_all -> cmd_predict; use getattr for missing attr

Fix src/anat2vessels/preprocess.py:
  - Pass bids_dir string instead of BIDSLayout object to Ray remote tasks
  - BIDSLayout is not serializable/picklable; reconstruct inside remote function

Fix src/anat2vessels/vessels2csv.py:
  - Add ignore_reinit_error=True to ray.init() to allow reuse across pipeline stages

Fix README.md:
  - Document ARM64 build, fetch-test-data workflow, and pooch cache mount